### PR TITLE
added a job to check on fax queue status

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -19,7 +19,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // Cache the job settings for 2 hours (120 minutes)
+        // Cache the job settings for 2 minutes (120 seconds)
         $jobSettings = Cache::remember('scheduled_jobs_settings', 120, function () {
             return DefaultSettings::where('default_setting_category', 'scheduled_jobs')
                 ->where('default_setting_enabled', true)
@@ -34,7 +34,7 @@ class Kernel extends ConsoleKernel
             $schedule->command('UploadArchiveFiles')
                 ->dailyAt('01:00')
                 ->timezone('America/Los_Angeles');
-        } 
+        }
 
         // Clear the export directory
         if (isset($jobSettings['clear_export_directory']) && $jobSettings['clear_export_directory'] === "true") {
@@ -64,10 +64,15 @@ class Kernel extends ConsoleKernel
         }
 
         if (isset($jobSettings['backup']) && $jobSettings['backup'] === "true") {
-                // Schedule the backup command to run at 2 AM daily
-                $schedule->command('app:backup')
+            // Schedule the backup command to run at 2 AM daily
+            $schedule->command('app:backup')
                 ->dailyAt('02:00')
                 ->timezone('America/Los_Angeles');
+        }
+
+        // Check fax service status
+        if (isset($jobSettings['check_fax_service_status']) && $jobSettings['check_fax_service_status'] === "true") {
+            $schedule->job(new \App\Jobs\CheckFaxServiceStatus())->everyThirtyMinutes();
         }
     }
 

--- a/app/Jobs/CheckFaxServiceStatus.php
+++ b/app/Jobs/CheckFaxServiceStatus.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\FaxQueues;
+use Illuminate\Bus\Queueable;
+use App\Models\DefaultSettings;
+use Illuminate\Support\Facades\Redis;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\Middleware\RateLimitedWithRedis;
+use App\Jobs\SendFaxQueueThresholdExceededNotification;
+
+class CheckFaxServiceStatus implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * The number of times the job may be attempted.
+     *
+     * @var int
+     */
+    public $tries = 10;
+
+    /**
+     * The maximum number of unhandled exceptions to allow before failing.
+     *
+     * @var int
+     */
+    public $maxExceptions = 5;
+
+    /**
+     * The number of seconds the job can run before timing out.
+     *
+     * @var int
+     */
+    public $timeout = 120;
+
+    /**
+     * Indicate if the job should be marked as failed on timeout.
+     *
+     * @var bool
+     */
+    public $failOnTimeout = true;
+
+    /**
+     * The number of seconds to wait before retrying the job.
+     *
+     * @var int
+     */
+    public $backoff = 300;
+
+    /**
+     * Delete the job if its models no longer exist.
+     *
+     * @var bool
+     */
+    public $deleteWhenMissingModels = true;
+
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array
+     */
+    public function middleware()
+    {
+        return [(new RateLimitedWithRedis('default'))];
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        // Allow only 2 tasks every 1 second
+        Redis::throttle('default')->allow(1)->every(30)->then(function () {
+
+            // Retrieve the fax service settings
+            $threshold = DefaultSettings::where('default_setting_category', 'scheduled_jobs')
+                ->where('default_setting_subcategory', 'fax_service_threshold')
+                ->value('default_setting_value') ?? 10;
+
+            $waitTimeThreshold = DefaultSettings::where('default_setting_category', 'scheduled_jobs')
+                ->where('default_setting_subcategory', 'fax_wait_time_threshold')
+                ->value('default_setting_value') ?? 30;
+
+            // Retrieve notification email
+            $notifyEmail = DefaultSettings::where('default_setting_category', 'scheduled_jobs')
+                ->where('default_setting_subcategory', 'fax_service_notify_email')
+                ->value('default_setting_value') ?? null;
+
+            // Calculate the time threshold
+            $timeThreshold = now()->subMinutes($waitTimeThreshold)->toIso8601String();
+
+            // Get pending faxes that exceed the wait time threshold
+            $pendingFaxes = FaxQueues::where('fax_status', 'waiting')
+                ->where('fax_date', '<', $timeThreshold)
+                ->count();
+
+            logger('Threshold - ' . $threshold);
+            logger('waitTimeThreshold - ' . $waitTimeThreshold);
+            logger('timeThreshold - ' . $timeThreshold);
+            logger('pendingFaxes - ' . $pendingFaxes);
+
+            // $pendingFaxes = FaxQueues::where('fax_status', 'waiting')
+            //     ->where('fax_date', '<', $timeThreshold)
+            //     ->get();
+
+            // logger($pendingFaxes);
+
+            if ($pendingFaxes >= $threshold) {
+                logger("Fax service alert: {$pendingFaxes} faxes have been pending for longer than {$waitTimeThreshold} minutes. Check fax queue service status");
+
+                if ($notifyEmail) {
+                    $params['notifyEmail'] = $notifyEmail;
+                    $params['pendingFaxes'] = $pendingFaxes;
+                    $params['waitTimeThreshold'] = $waitTimeThreshold;
+                    $params['email_subject'] = config('app.name', 'Laravel') . ' fax service alert';
+
+                    $this->notifyAdmin($params);
+                }
+            }
+        }, function () {
+            // Could not obtain lock; this job will be re-queued
+            return $this->release(30);
+        });
+    }
+
+    /**
+     * Notify the admin
+     */
+    protected function notifyAdmin($params)
+    {
+        SendFaxQueueThresholdExceededNotification::dispatch($params)->onQueue('emails');
+
+    }
+}

--- a/app/Mail/FaxQueueStatus.php
+++ b/app/Mail/FaxQueueStatus.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Mail\Mailables\Content;
+
+
+class FaxQueueStatus extends BaseMailable
+{
+
+    public function __construct($params)
+    {
+        parent::__construct($params);
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        // Add line unsubscrible header
+        $this->buildMessageHeaders();
+
+        return $this->from(config('mail.from.address'), config('mail.from.name'));
+        // ->subject('Call history report');
+
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.fax.fax-queue-status',
+            text: 'emails.fax.fax-queue-status-text'
+        );
+    }
+}

--- a/config/version.php
+++ b/config/version.php
@@ -2,6 +2,6 @@
 
 return [
 
-    'release' => '0.9.33',
+    'release' => '0.9.34',
     
 ];

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -449,10 +449,39 @@ class DatabaseSeeder extends Seeder
                 'default_setting_enabled'       => true,
                 'default_setting_description'   => "",
             ],
-
-
-
-
+            [
+                'default_setting_category'      => 'scheduled_jobs',
+                'default_setting_subcategory'   => 'check_fax_service_status',
+                'default_setting_name'          => 'boolean',
+                'default_setting_value'         => "false",
+                'default_setting_enabled'       => false,
+                'default_setting_description'   => "Monitors pending faxes and identifies those exceeding the allowed threshold.",
+            ],
+            [
+                'default_setting_category'      => 'scheduled_jobs',
+                'default_setting_subcategory'   => 'fax_service_threshold',
+                'default_setting_name'          => 'text',
+                'default_setting_value'         => "5",
+                'default_setting_enabled'       => true,
+                'default_setting_description'   => "Defines the maximum number of pending faxes allowed before exceeding the threshold.",
+            ],
+            [
+                'default_setting_category'      => 'scheduled_jobs',
+                'default_setting_subcategory'   => 'fax_wait_time_threshold',
+                'default_setting_name'          => 'text',
+                'default_setting_value'         => "60", 
+                'default_setting_enabled'       => true,
+                'default_setting_description'   => "Specifies the number of minutes a fax can remain in waiting status before being counted against the threshold.",
+            ],
+            [
+                'default_setting_category'      => 'scheduled_jobs',
+                'default_setting_subcategory'   => 'fax_service_notify_email',
+                'default_setting_name'          => 'text',
+                'default_setting_value'         => "",
+                'default_setting_enabled'       => true,
+                'default_setting_description'   => "Email address to receive notifications when pending faxes exceed the allowed wait time threshold.",
+            ],
+            
 
         ];
 

--- a/resources/views/emails/fax/fax-queue-status-text.blade.php
+++ b/resources/views/emails/fax/fax-queue-status-text.blade.php
@@ -1,0 +1,7 @@
+Fax service alert
+
+{{ $attributes["pendingFaxes"] ?? ''}} faxes have been pending for longer than {{ $attributes["waitTimeThreshold"] ?? ''}} minutes. Check fax queue service status.
+
+Thanks,
+
+{{ config('app.name', 'Laravel') }} Team

--- a/resources/views/emails/fax/fax-queue-status.blade.php
+++ b/resources/views/emails/fax/fax-queue-status.blade.php
@@ -1,0 +1,14 @@
+@extends('emails.email_layout')
+
+@section('content')
+<!-- Start Content-->
+
+<h1>Fax service alert</h1>
+<p>{{ $attributes["pendingFaxes"] ?? ''}} faxes have been pending for longer than {{ $attributes["waitTimeThreshold"] ?? ''}} minutes. Check fax queue service status.</p>
+<!-- Action -->
+
+<p>Thanks,
+<br>{{ config('app.name', 'Laravel') }} Team</p>
+
+
+@endsection


### PR DESCRIPTION
The job runs every 30 minutes, checking for faxes that have remained in "waiting" status beyond a specified threshold. If any are found, an alert email is sent. The threshold and other settings can be adjusted in Default Settings.