### PR TITLE
fix: send password reset emails through the branded email template system

### DIFF
--- a/app/Mail/ResetPasswordMail.php
+++ b/app/Mail/ResetPasswordMail.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Mail\Mailables\Content;
+
+class ResetPasswordMail extends BaseMailable
+{
+    public function __construct(array $attributes)
+    {
+        $attributes['greeting_name'] = filled($attributes['name'] ?? null)
+            ? ' '.$attributes['name']
+            : '';
+        $attributes['email_subject'] = 'Reset Password Notification';
+
+        parent::__construct($attributes);
+        $this->useEmailTemplate('authentication', 'reset-password');
+    }
+
+    public function content(): Content
+    {
+        return $this->databaseTemplateContent(new Content(
+            view: 'emails.authentication.reset-password',
+            text: 'emails.authentication.reset-password-text',
+        ));
+    }
+}

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -10,6 +10,7 @@ use App\Actions\Fortify\UpdateUserProfileInformation;
 use App\Mail\ResetPasswordMail;
 use App\Models\DefaultSettings;
 use App\Services\LdapUserAuthenticator;
+use App\Support\Localization\LocaleRegistry;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
@@ -46,22 +47,25 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::updateUserPasswordsUsing(UpdateUserPassword::class);
         Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
 
-        // Laravel's default ResetPassword notification renders its own hardcoded
-        // MailMessage, bypassing the app's branded email_templates system (no
-        // header/footer, no admin-editable copy). Route it through the same
-        // BaseMailable-based flow every other transactional email uses.
+        // Use editable email templates while retaining Laravel's reset-token flow.
         ResetPassword::toMailUsing(function ($notifiable, string $token) {
+            $domainUuid = $notifiable->domain_uuid;
+            $email = $notifiable->getEmailForPasswordReset();
             $url = url(route('password.reset', [
                 'token' => $token,
-                'email' => $notifiable->getEmailForPasswordReset(),
+                'email' => $email,
             ], false));
 
-            return new ResetPasswordMail([
-                'email' => $notifiable->getEmailForPasswordReset(),
+            return (new ResetPasswordMail([
+                'domain_uuid' => $domainUuid,
+                'language' => app(LocaleRegistry::class)->resolve(
+                    $domainUuid ? get_domain_setting('language', $domainUuid) : null
+                ),
+                'email' => $email,
                 'name' => $notifiable->name_formatted ?? null,
                 'url' => $url,
                 'expire_minutes' => config('auth.passwords.'.config('auth.defaults.passwords').'.expire'),
-            ]);
+            ]))->to($email);
         });
 
         Fortify::authenticateUsing(function (Request $request) {

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -7,8 +7,10 @@ use App\Actions\Fortify\RedirectToEmailChallengeIf2FAIsNotEnabled;
 use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
 use App\Actions\Fortify\UpdateUserProfileInformation;
+use App\Mail\ResetPasswordMail;
 use App\Models\DefaultSettings;
 use App\Services\LdapUserAuthenticator;
+use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
@@ -43,6 +45,25 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::updateUserProfileInformationUsing(UpdateUserProfileInformation::class);
         Fortify::updateUserPasswordsUsing(UpdateUserPassword::class);
         Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
+
+        // Laravel's default ResetPassword notification renders its own hardcoded
+        // MailMessage, bypassing the app's branded email_templates system (no
+        // header/footer, no admin-editable copy). Route it through the same
+        // BaseMailable-based flow every other transactional email uses.
+        ResetPassword::toMailUsing(function ($notifiable, string $token) {
+            $url = url(route('password.reset', [
+                'token' => $token,
+                'email' => $notifiable->getEmailForPasswordReset(),
+            ], false));
+
+            return new ResetPasswordMail([
+                'email' => $notifiable->getEmailForPasswordReset(),
+                'name' => $notifiable->name_formatted ?? null,
+                'url' => $url,
+                'expire_minutes' => config('auth.passwords.'.config('auth.defaults.passwords').'.expire'),
+            ]);
+        });
+
         Fortify::authenticateUsing(function (Request $request) {
             return app(LdapUserAuthenticator::class)->authenticate(
                 (string) $request->input(Fortify::username()),

--- a/app/Services/EmailTemplatePreviewService.php
+++ b/app/Services/EmailTemplatePreviewService.php
@@ -85,6 +85,8 @@ class EmailTemplatePreviewService
             'portal_email' => 'jordan@example.test',
             'portal_login_url' => 'https://example.test/login',
             'password_request_url' => 'https://example.test/forgot-password',
+            'url' => 'https://example.test/reset-password/sample-token?email=jordan%40example.test',
+            'expire_minutes' => config('auth.passwords.'.config('auth.defaults.passwords').'.expire', 60),
 
             'hostname' => 'pbx.example.test',
             'success' => ['recording-001.wav', 'recording-002.wav'],

--- a/resources/views/emails/authentication/reset-password-text.blade.php
+++ b/resources/views/emails/authentication/reset-password-text.blade.php
@@ -1,0 +1,20 @@
+{{-- email-template
+format: text
+layout: none
+--}}
+Hello{{ isset($attributes['name']) ? ' ' . $attributes['name'] : '' }},
+
+You are receiving this email because we received a password reset request for your {{ config('app.name', 'Laravel') }} account.
+
+Reset your password: {{ $attributes['url'] ?? '' }}
+
+This password reset link will expire in {{ $attributes['expire_minutes'] ?? '' }} minutes.
+
+If you did not request a password reset, no further action is required.
+
+If you have any questions, email our customer success team at {{ $attributes['support_email'] ?? '' }}.
+
+Stay secure,
+The {{ config('app.name', 'Laravel') }} Team
+
+Do not reply to this email as it is an automated message and responses are not monitored.

--- a/resources/views/emails/authentication/reset-password.blade.php
+++ b/resources/views/emails/authentication/reset-password.blade.php
@@ -1,0 +1,31 @@
+{{-- email-template
+version: 1.0.0
+language: en-us
+category: authentication
+subcategory: reset-password
+format: html
+layout: standard
+subject: {{ $email_subject }}
+description: Password reset link
+--}}
+@extends('emails.email_layout')
+
+@section('content')
+<!-- Start Content-->
+
+<p>Hello{{ isset($attributes['name']) ? ' ' . $attributes['name'] : '' }},</p>
+
+<p>You are receiving this email because we received a password reset request for your {{ config('app.name', 'Laravel') }} account.</p>
+
+<p><a href="{{ $attributes['url'] ?? '' }}">Reset Password</a></p>
+
+<p>This password reset link will expire in {{ $attributes['expire_minutes'] ?? '' }} minutes.</p>
+
+<p>If you did not request a password reset, no further action is required.</p>
+
+<p>If you have any questions, <a href="mailto:{{ $attributes["support_email"] ?? ''}}">email our customer success team</a>.</p>
+
+<p>Stay secure, <br>
+The {{ config('app.name', 'Laravel') }} Team</p>
+
+@endsection

--- a/tests/Unit/EmailTemplatePreviewServiceTest.php
+++ b/tests/Unit/EmailTemplatePreviewServiceTest.php
@@ -46,6 +46,18 @@ class EmailTemplatePreviewServiceTest extends TestCase
         $this->assertStringNotContainsString('{{', $preview['text']);
     }
 
+    public function test_password_reset_preview_includes_link_and_expiration_in_both_formats(): void
+    {
+        $definition = app(EmailTemplateSourceService::class)->definitions()['authentication.reset-password|en-us'];
+        $preview = app(EmailTemplatePreviewService::class)->render($definition);
+
+        foreach (['html', 'text'] as $format) {
+            $this->assertStringContainsString('https://example.test/reset-password/sample-token?email=jordan%40example.test', $preview[$format]);
+            $this->assertStringContainsString(config('auth.passwords.users.expire').' minutes', $preview[$format]);
+            $this->assertStringContainsString('Jordan Lee', $preview[$format]);
+        }
+    }
+
     public function test_every_default_template_can_render_a_preview(): void
     {
         $previewer = app(EmailTemplatePreviewService::class);

--- a/tests/Unit/ResetPasswordMailTest.php
+++ b/tests/Unit/ResetPasswordMailTest.php
@@ -3,10 +3,16 @@
 namespace Tests\Unit;
 
 use App\Mail\ResetPasswordMail;
+use App\Models\User;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Notifications\Channels\MailChannel;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Illuminate\View\Compilers\Compiler;
+use ReflectionProperty;
 use Tests\TestCase;
 
 class ResetPasswordMailTest extends TestCase
@@ -16,6 +22,11 @@ class ResetPasswordMailTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        $compiledPath = '/tmp/fspbx-reset-password-mail-tests';
+        File::ensureDirectoryExists($compiledPath);
+        config(['view.compiled' => $compiledPath, 'mail.default' => 'array', 'mail.from.address' => 'noreply@example.test']);
+        (new ReflectionProperty(Compiler::class, 'cachePath'))->setValue(app('blade.compiler'), $compiledPath);
 
         $this->originalConnection = config('database.default');
         config()->set('database.connections.reset_password_mail_test', [
@@ -36,6 +47,13 @@ class ResetPasswordMailTest extends TestCase
             $table->string('default_setting_category');
             $table->string('default_setting_subcategory');
             $table->string('default_setting_value')->nullable();
+            $table->string('default_setting_enabled')->default('true');
+        });
+        Schema::create('v_domain_settings', function (Blueprint $table) {
+            $table->uuid('domain_uuid');
+            $table->string('domain_setting_subcategory');
+            $table->string('domain_setting_value')->nullable();
+            $table->string('domain_setting_enabled')->default('true');
         });
     }
 
@@ -52,6 +70,7 @@ class ResetPasswordMailTest extends TestCase
         $notifiable = new class
         {
             public string $name_formatted = 'Jordan';
+            public ?string $domain_uuid = null;
 
             public function getEmailForPasswordReset(): string
             {
@@ -64,6 +83,7 @@ class ResetPasswordMailTest extends TestCase
         $this->assertInstanceOf(ResetPasswordMail::class, $mail);
         $this->assertSame('jordan@example.test', $mail->attributes['email']);
         $this->assertSame('Jordan', $mail->attributes['name']);
+        $this->assertTrue($mail->hasTo('jordan@example.test'));
         $this->assertStringContainsString('/test-token', $mail->attributes['url']);
         $this->assertStringContainsString('email=jordan%40example.test', $mail->attributes['url']);
     }
@@ -97,5 +117,114 @@ class ResetPasswordMailTest extends TestCase
         ]);
 
         $this->assertSame('Reset Password Notification', $mail->attributes['email_subject']);
+    }
+
+    public function test_notification_delivers_html_and_text_with_the_reset_link(): void
+    {
+        // Keep delivery real, but isolate unrelated email-log persistence.
+        \Illuminate\Support\Facades\Event::fake([
+            \Illuminate\Mail\Events\MessageSending::class,
+            \Illuminate\Mail\Events\MessageSent::class,
+        ]);
+        $user = $this->recipient();
+        app(MailChannel::class)->send($user, new ResetPassword('test-token'));
+
+        $messages = app('mailer')->getSymfonyTransport()->messages();
+        $this->assertCount(1, $messages);
+        $message = $messages->first()->getOriginalMessage();
+        $this->assertSame('jordan@example.test', $message->getTo()[0]->getAddress());
+        $this->assertSame('Reset Password Notification', $message->getSubject());
+        $url = url(route('password.reset', ['token' => 'test-token', 'email' => $user->user_email], false));
+        foreach ([$message->getHtmlBody(), $message->getTextBody()] as $body) {
+            $this->assertStringContainsString($url, html_entity_decode($body));
+            $this->assertStringContainsString(config('auth.passwords.users.expire').' minutes', $body);
+        }
+    }
+
+    public function test_recipient_account_override_wins_and_other_accounts_are_excluded(): void
+    {
+        $this->createTemplateTable();
+        $user = $this->recipient();
+        session(['domain_uuid' => '22222222-2222-4222-8222-222222222222']);
+        $this->template('default', null, 'Default');
+        $this->template('custom', null, 'Global');
+        $this->template('custom', session('domain_uuid'), 'Other account');
+        $this->template('custom', $user->domain_uuid, 'Recipient account');
+
+        $mail = (new ResetPassword('test-token'))->toMail($user);
+        $this->assertSame($user->domain_uuid, $mail->attributes['domain_uuid']);
+        $this->assertSame('Recipient account', $mail->attributes['email_subject']);
+        $this->assertStringContainsString('Recipient account', $mail->render());
+
+        DB::table('email_templates')->where('domain_uuid', $user->domain_uuid)->delete();
+        $this->assertSame('Global', (new ResetPassword('test-token'))->toMail($user)->attributes['email_subject']);
+        DB::table('email_templates')->whereNull('domain_uuid')->where('template_type', 'custom')->delete();
+        $this->assertSame('Default', (new ResetPassword('test-token'))->toMail($user)->attributes['email_subject']);
+    }
+
+    public function test_recipient_language_is_normalized_and_missing_translation_falls_back_to_english(): void
+    {
+        $this->createTemplateTable();
+        $user = $this->recipient();
+        session(['domain_uuid' => '22222222-2222-4222-8222-222222222222', 'domain.language.code' => 'en-us']);
+        DB::table('v_domain_settings')->insert([
+            'domain_uuid' => $user->domain_uuid,
+            'domain_setting_subcategory' => 'language',
+            'domain_setting_value' => ' ES-ES ',
+        ]);
+        $this->template('custom', $user->domain_uuid, 'English');
+        $this->template('custom', $user->domain_uuid, 'Spanish', 'es-es');
+        $mail = (new ResetPassword('test-token'))->toMail($user);
+        $this->assertSame('es-es', $mail->attributes['language']);
+        $this->assertSame('Spanish', $mail->attributes['email_subject']);
+
+        DB::table('email_templates')->where('template_language', 'es-es')->delete();
+        $this->assertSame('English', (new ResetPassword('test-token'))->toMail($user)->attributes['email_subject']);
+        DB::table('v_domain_settings')->update(['domain_setting_value' => 'unsupported']);
+        $mail = (new ResetPassword('test-token'))->toMail($user);
+        $this->assertSame('en-us', $mail->attributes['language']);
+        $this->assertSame('English', $mail->attributes['email_subject']);
+    }
+
+    private function recipient(): User
+    {
+        $user = new User;
+        $user->user_email = 'jordan@example.test';
+        $user->domain_uuid = '11111111-1111-4111-8111-111111111111';
+
+        return $user;
+    }
+
+    private function createTemplateTable(): void
+    {
+        Schema::create('email_templates', function (Blueprint $table) {
+            $table->uuid('email_template_uuid')->primary();
+            $table->uuid('domain_uuid')->nullable();
+            $table->string('template_key');
+            $table->string('template_type');
+            $table->string('template_language');
+            $table->string('template_layout');
+            $table->string('template_subject');
+            $table->text('template_html');
+            $table->text('template_text');
+            $table->boolean('template_enabled');
+            $table->timestamps();
+        });
+    }
+
+    private function template(string $type, ?string $domainUuid, string $subject, string $language = 'en-us'): void
+    {
+        DB::table('email_templates')->insert([
+            'email_template_uuid' => (string) Str::uuid(),
+            'domain_uuid' => $domainUuid,
+            'template_key' => 'authentication.reset-password',
+            'template_type' => $type,
+            'template_language' => $language,
+            'template_layout' => 'none',
+            'template_subject' => $subject,
+            'template_html' => '<p>'.$subject.'</p><a href="{{ $attributes[\'url\'] }}">Reset</a>',
+            'template_text' => $subject.' {{ $attributes[\'url\'] }}',
+            'template_enabled' => true,
+        ]);
     }
 }

--- a/tests/Unit/ResetPasswordMailTest.php
+++ b/tests/Unit/ResetPasswordMailTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Mail\ResetPasswordMail;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class ResetPasswordMailTest extends TestCase
+{
+    private string $originalConnection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalConnection = config('database.default');
+        config()->set('database.connections.reset_password_mail_test', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+            'foreign_key_constraints' => true,
+        ]);
+        config()->set('database.default', 'reset_password_mail_test');
+        DB::purge('reset_password_mail_test');
+
+        // Minimal schema for BaseMailable::mergeDefaultSettings(); no email_templates
+        // table, so the mail renders from the shipped file-based template source
+        // (App\Services\EmailTemplateSourceService), exercising the real template
+        // file on disk.
+        Schema::create('v_default_settings', function (Blueprint $table) {
+            $table->uuid('default_setting_uuid')->primary();
+            $table->string('default_setting_category');
+            $table->string('default_setting_subcategory');
+            $table->string('default_setting_value')->nullable();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        DB::disconnect('reset_password_mail_test');
+        config()->set('database.default', $this->originalConnection);
+
+        parent::tearDown();
+    }
+
+    public function test_the_reset_password_notification_is_routed_through_the_branded_mailable(): void
+    {
+        $notifiable = new class
+        {
+            public string $name_formatted = 'Jordan';
+
+            public function getEmailForPasswordReset(): string
+            {
+                return 'jordan@example.test';
+            }
+        };
+
+        $mail = (new ResetPassword('test-token'))->toMail($notifiable);
+
+        $this->assertInstanceOf(ResetPasswordMail::class, $mail);
+        $this->assertSame('jordan@example.test', $mail->attributes['email']);
+        $this->assertSame('Jordan', $mail->attributes['name']);
+        $this->assertStringContainsString('/test-token', $mail->attributes['url']);
+        $this->assertStringContainsString('email=jordan%40example.test', $mail->attributes['url']);
+    }
+
+    public function test_content_renders_the_reset_link_and_expiry(): void
+    {
+        $mail = new ResetPasswordMail([
+            'email' => 'jordan@example.test',
+            'name' => 'Jordan',
+            'url' => 'https://pbx.example.test/reset-password/test-token?email=jordan%40example.test',
+            'expire_minutes' => 60,
+        ]);
+
+        $rendered = $mail->render();
+
+        $this->assertStringContainsString(
+            'https://pbx.example.test/reset-password/test-token',
+            $rendered
+        );
+        $this->assertStringContainsString('60 minutes', $rendered);
+        $this->assertStringContainsString('Jordan', $rendered);
+    }
+
+    public function test_subject_falls_back_to_the_shipped_template_subject(): void
+    {
+        $mail = new ResetPasswordMail([
+            'email' => 'jordan@example.test',
+            'name' => 'Jordan',
+            'url' => 'https://pbx.example.test/reset-password/test-token',
+            'expire_minutes' => 60,
+        ]);
+
+        $this->assertSame('Reset Password Notification', $mail->attributes['email_subject']);
+    }
+}

--- a/tests/Unit/SafeEmailTemplateRendererTest.php
+++ b/tests/Unit/SafeEmailTemplateRendererTest.php
@@ -28,11 +28,12 @@ class SafeEmailTemplateRendererTest extends TestCase
     {
         $definitions = app(EmailTemplateSourceService::class)->definitions();
 
-        $this->assertCount(22, $definitions);
+        $this->assertCount(23, $definitions);
         $this->assertArrayHasKey('ai-agent.send-email|en-us', $definitions);
         $this->assertArrayHasKey('extension.welcome|en-us', $definitions);
         $this->assertArrayHasKey('voicemail.default|en-us', $definitions);
         $this->assertArrayHasKey('voicemail.transcription|en-us', $definitions);
+        $this->assertArrayHasKey('authentication.reset-password|en-us', $definitions);
 
         foreach ($definitions as $definition) {
             $this->assertNotSame('', $definition['template_subject']);


### PR DESCRIPTION
Fixes #602

Password reset emails now use FS PBX’s Email Templates system, allowing administrators to customize their subject, HTML, and plain-text content. Laravel continues to manage reset tokens and password updates.

The notification explicitly sets the recipient and selects templates using the recipient’s account and configured language, including the existing English fallback. Preview data includes a sample reset link and expiration. The normal email template seeder discovers the new authentication.reset-password template; no schema migration is required.

Validation: 17 focused tests passed (258 assertions) across ResetPasswordMailTest, EmailTemplatePreviewServiceTest, SafeEmailTemplateRendererTest, and EmailTemplatesSeedTest. Coverage includes notification-channel delivery using an in-memory mail transport, account override precedence and isolation, language selection and English fallback, and HTML/plain-text previews. PHP syntax checks and git diff --check passed. No real emails were sent.